### PR TITLE
Finish initial dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,21 @@
-FROM node:10.15.3
-COPY package.json /var/apps/iarl/package.json
-WORKDIR /var/apps/iarl/
-RUN npm install
+FROM node:8
+
+WORKDIR /iarl-nodejs
+
+COPY . /iarl-nodejs
+
+EXPOSE 8080
+
+RUN \
+    sed -i 's/# \(.*multiverse$\)/\1/g' /etc/apt/sources.list && \    
+    apt-get update -y && \    
+    apt-get upgrade -y && \
+    apt-get install -y apt-transport-https apt-utils ca-certificates \
+    software-properties-common curl htop man unzip vim nano wget \ 
+    net-tools iputils-ping && \
+    apt-get update    
+
+ARG BASE_DIR
+ARG IARL_JWT_PRIVATE_KEY
+
+CMD ["sh","-c","npm install && BASE_DIR=${BASE_DIR} IARL_JWT_PRIVATE_KEY=${IARL_JWT_PRIVATE_KEY} npm start"]


### PR DESCRIPTION
This PR fix  #97 updating the Dockerfile to its first version. Below I share some useful docker commands.

To build: `docker build -t iarl-nodejs .`
To push: `docker tag iarl-nodejs guardiansdsc/iarl-nodejs && docker push guardiansdsc/iarl-nodejs`
To run: `docker run -e "BASE_DIR=you_base_dir" -e "IARL_JWT_PRIVATE_KEY=you_jwt_private_key" -dit --name iarl-nodejs -p port_you_want_to_run:3000 -p 389:389 -p 689:689 -v /you_base_dir:/you_base_dir guardiansdsc/iarl-nodejs`